### PR TITLE
Use the default provider chain

### DIFF
--- a/R/jdbc.r
+++ b/R/jdbc.r
@@ -22,7 +22,7 @@ setMethod(
   "AthenaDriver",
 
   def = function(drv,
-                 provider = "com.amazonaws.athena.jdbc.shaded.com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+                 provider = "com.amazonaws.athena.jdbc.shaded.com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
                  region = "us-east-1",
                  s3_staging_dir = Sys.getenv("AWS_S3_STAGING_DIR"),
                  schema_name = "default",


### PR DESCRIPTION
Most AWS integration (boto, cli, etc.) uses the Default AWS Credential Provider Chain (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). This simply steps through a number of authentication methods to pull AWS access keys.

The current version of metis uses a combination of `EnvironmentVariableCredentialsProvider` and `aws.signature` to load credentials. While this is great, since, this R package is based on Rjava, and Rjava loads the Java environment up once when it's initialized, keys cannot be changed without re-initializing Rjava. For RStudio, I've had to quit and re-enter to update keys. This is particularly problematic for situations where temporary access tokens are used.

This simple fix just delegates back to Java to make the decision on where to grab keys from. You can still use `aws.signature` as the docs say today as is. However, you don't have to now, and can benefit from the fallback chain the default provider has.